### PR TITLE
Very primitive first implementation of code complete 

### DIFF
--- a/eval-api/src/main/thrift/ca.polymtl.log4900.api.eval/api.thrift
+++ b/eval-api/src/main/thrift/ca.polymtl.log4900.api.eval/api.thrift
@@ -1,5 +1,6 @@
 namespace scala ca.polymtl.log4900.api.eval
 
 service Insight {
-	list<string> eval(1: string code)
+	string eval(1: string code)
+	list<string> codeComplete(1: string code, 2: i32 pos)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
 		"org.webjars" %% "webjars-play" % "2.2.0-RC1"
 	)
 
-	val specs2 = "org.specs2" %% "specs2" % "2.2.2" % "test"
+	val specs2 = "org.specs2" %% "specs2" % "2.2.3" % "test"
 	val test = Seq(specs2)
 	val securesocial = ("securesocial" %% "securesocial" % "master-SNAPSHOT") exclude("org.scala-stm", "scala-stm_2.10.0")
 }

--- a/scalaEval/src/test/scala/ca.polymtl.log4900.eval/.keep
+++ b/scalaEval/src/test/scala/ca.polymtl.log4900.eval/.keep
@@ -1,1 +1,0 @@
-write some tests lazy you!

--- a/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
+++ b/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
@@ -1,0 +1,32 @@
+package ca.polymtl.log4900
+package eval
+
+import org.specs2.mutable._
+
+class ServerSpec extends Specification {
+
+	"codeComplete" should {
+		"work when there is something to complete" in {
+			val server = new InsightImpl()
+			val code = """object wtv {
+						 |val aabb = "cat"
+						 |aabb.subS
+						 |}""".stripMargin
+			val result = server.codeComplete(code, 32).get
+			result must contain("substring")
+		}
+		"work even when there is no wrapping object or class" in {
+			val server = new InsightImpl()
+			val code = """val aabb = "cat"
+						 |aabb.subS""".stripMargin
+			val result = server.codeComplete(code, 19).get
+			result must contain("substring")
+		}
+		"fail gracefully when there is nothing to complete" in {
+			val server = new InsightImpl()
+			val code = ""
+			val result = server.codeComplete(code, 1).get
+			result must beEmpty
+		}
+	}
+}

--- a/web/app/controllers/Application.scala
+++ b/web/app/controllers/Application.scala
@@ -29,9 +29,9 @@ object Application extends Controller with securesocial.core.SecureSocial {
       val callback = (content \ "callback_id").as[Int]
 
       Registry.getEval.map(service => {
-        service.eval(code).map(result =>{
+        service.eval(code).map(result => {
           channel.push(JsObject(Seq(
-            "response" -> JsArray(result.map(s => JsString(s))),
+            "response" -> JsString(result),
             "callback_id" -> JsNumber(callback)
           )))
         })

--- a/web/public/scripts/services/insight.js
+++ b/web/public/scripts/services/insight.js
@@ -22,7 +22,7 @@ app.factory('insight', ['$q', '$rootScope', "$location", function($q, $rootScope
 
 	function listener(data) {
 		if(callbacks.hasOwnProperty(data.callback_id)) {
-			var insight = data.response.join('\n');
+			var insight = data.response;
 			$rootScope.$apply(callbacks[data.callback_id].resolve(insight));
 			delete callbacks[data.callback_id];
 		}


### PR DESCRIPTION
- Use Presentation compiler to offer basic code complete back-end functionality
- Add setupReplClassPath sbt task, necessary for the Presentation compiler to work
- Add specs dependency to scalaEval project in order to start testing it
- Change api of eval to avoid needless string manipulation
- Upgrade to specs2 2.2.3
