### PR TITLE
Continue implementation error messages and code completion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,1 @@
+seq(bintrayResolverSettings:_*)

--- a/eval-api/src/main/thrift/ca.polymtl.log4900.api.eval/api.thrift
+++ b/eval-api/src/main/thrift/ca.polymtl.log4900.api.eval/api.thrift
@@ -1,6 +1,20 @@
 namespace scala ca.polymtl.log4900.api.eval
 
+enum Severity { INFO, WARNING, ERROR }
+
+struct CompilationInfo {
+	string message,
+	i32 pos,
+	Severity severity
+}
+
+struct Result {
+	string insight,
+	string output,
+	list<CompilationInfo> infos,
+	list<string> completions
+}
+
 service Insight {
-	string eval(1: string code)
-	list<string> codeComplete(1: string code, 2: i32 pos)
+	Result eval(1: string code, 2: i32 pos)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -39,7 +39,7 @@ object ApplicationBuild extends Build {
     base = file("scalaEval"),
     settings = Settings.default ++ packageArchetype.java_application ++ Seq(
       name := "scalaEval",
-      resolvers := Seq("codebrew's maven" at "http://codebrew-io.github.io/maven/"),
+      resolvers += bintray.Opts.resolver.repo("jedesah", "maven"),
       libraryDependencies ++= Seq(insight) ++ test,
       bashScriptExtraDefines += """addJava "-Duser.dir=$(cd "${app_home}/.."; pwd -P)" """,
       setupReplClassPath <<= (dependencyClasspath in Compile) map {cp =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-	val insight = "com.github.jedesah" %% "codesheet-api" % "0.3.0"
+	val insight = "com.github.jedesah" %% "codesheet-api" % "0.4.0"
 
 	private val finagleVer = "6.5.0"
 	lazy val thrift = "org.apache.thrift" % "libthrift" % "0.8.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,8 @@ resolvers ++= Seq(
 	"codebrew's maven" at "http://codebrew-io.github.io/maven/"
 )
 
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
 
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.9.0")

--- a/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
+++ b/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
@@ -12,21 +12,40 @@ class ServerSpec extends Specification {
 						 |val aabb = "cat"
 						 |aabb.subS
 						 |}""".stripMargin
-			val result = server.codeComplete(code, 32).get
-			result must contain("substring")
+			server.compileAndCompletion(code, 32) must beLike { case (compilationInfos, completions) =>
+				println(compilationInfos)
+				compilationInfos must not be empty
+				completions must contain("substring")
+			}
+		}
+		"work on the partial member name" in {
+			val server = new InsightImpl()
+			val code = """object wtv {
+						 |val aabb = "cat"
+						 |aabb.subS
+						 |}""".stripMargin
+			server.compileAndCompletion(code, 37) must beLike { case (compilationInfos, completions) =>
+				println(compilationInfos)
+				compilationInfos must not be empty
+				completions must contain("substring")
+			}
 		}
 		"work even when there is no wrapping object or class" in {
 			val server = new InsightImpl()
 			val code = """val aabb = "cat"
 						 |aabb.subS""".stripMargin
-			val result = server.codeComplete(code, 19).get
-			result must contain("substring")
+			server.compileAndCompletion(code, 19) must beLike { case (compilationInfos, completions) =>
+				compilationInfos must not be empty
+				completions must contain("substring")
+			}
 		}
 		"fail gracefully when there is nothing to complete" in {
 			val server = new InsightImpl()
 			val code = ""
-			val result = server.codeComplete(code, 1).get
-			result must beEmpty
+			server.compileAndCompletion(code, 1) must beLike { case (compilationInfos, completions) =>
+				compilationInfos must be empty;
+				completions must be empty
+			}
 		}
 	}
 }

--- a/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
+++ b/scalaEval/src/test/scala/ca.polymtl.log4900.eval/ServerSpec.scala
@@ -14,7 +14,7 @@ class ServerSpec extends Specification {
 						 |}""".stripMargin
 			server.compileAndCompletion(code, 32) must beLike { case (compilationInfos, completions) =>
 				println(compilationInfos)
-				compilationInfos must not be empty
+				compilationInfos must be empty;
 				completions must contain("substring")
 			}
 		}
@@ -26,7 +26,7 @@ class ServerSpec extends Specification {
 						 |}""".stripMargin
 			server.compileAndCompletion(code, 37) must beLike { case (compilationInfos, completions) =>
 				println(compilationInfos)
-				compilationInfos must not be empty
+				compilationInfos must not be empty;
 				completions must contain("substring")
 			}
 		}
@@ -35,14 +35,14 @@ class ServerSpec extends Specification {
 			val code = """val aabb = "cat"
 						 |aabb.subS""".stripMargin
 			server.compileAndCompletion(code, 19) must beLike { case (compilationInfos, completions) =>
-				compilationInfos must not be empty
+				compilationInfos must be empty;
 				completions must contain("substring")
 			}
 		}
 		"fail gracefully when there is nothing to complete" in {
 			val server = new InsightImpl()
 			val code = ""
-			server.compileAndCompletion(code, 1) must beLike { case (compilationInfos, completions) =>
+			server.compileAndCompletion(code, 0) must beLike { case (compilationInfos, completions) =>
 				compilationInfos must be empty;
 				completions must be empty
 			}

--- a/web/app/controllers/Application.scala
+++ b/web/app/controllers/Application.scala
@@ -48,9 +48,9 @@ object Application extends Controller with securesocial.core.SecureSocial {
       val callback = (content \ "callback_id").as[Int]
 
       Registry.getEval.map(service => {
-        service.eval(code).map(result => {
+        service.eval(code, 0).map(result => {
           channel.push(JsObject(Seq(
-            "response" -> JsString(result),
+            "response" -> JsString(result.insight),
             "callback_id" -> JsNumber(callback)
           )))
         })


### PR DESCRIPTION
- Update thrift interface
- Use bintray for codesheet dependency
- Update version of codesheet from 0.3.0 to 0.4.0
- Implement error retrieval using presentation compiler
